### PR TITLE
fixed error for start and end dates validations

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -11,7 +11,7 @@ class BookingsController < ApplicationController
     if @booking.save
       redirect_to my_bookings_path(current_user)
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -5,9 +5,11 @@ class Booking < ApplicationRecord
   validates :end_date, presence: true
   validate :start_before_end
 
+  private
+
   def start_before_end
-    if start_date > end_date
-      errors.add(:start_date, "Start date cannot be later than end date.")
-    end
+    return if end_date.blank? || start_date.blank?
+
+    errors.add(:start_date, " cannot be later than end date.") if start_date > end_date
   end
 end


### PR DESCRIPTION
I have fixed the dates validations errors. Now if the user doesn't input either the start or the end page, or those dates are mixed up, he will see the error.